### PR TITLE
Update GWikiFileStorage.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 target/
 classes/
 
+# intellij files
+*.iml
+.idea
+
 #eclipse files
 **/*.project
 **/*.classpath

--- a/gwiki/src/main/java/de/micromata/genome/gwiki/spi/storage/GWikiFileStorage.java
+++ b/gwiki/src/main/java/de/micromata/genome/gwiki/spi/storage/GWikiFileStorage.java
@@ -90,7 +90,7 @@ public class GWikiFileStorage implements GWikiStorage
   /**
    * The standard lock timeout.
    */
-  protected long standardLockTimeout = TimeInMillis.SECOND * 100;
+  protected long standardLockTimeout = 10;
 
   /**
    * The storage.

--- a/gwiki/src/main/java/de/micromata/genome/gwiki/spi/storage/GWikiFileStorage.java
+++ b/gwiki/src/main/java/de/micromata/genome/gwiki/spi/storage/GWikiFileStorage.java
@@ -90,7 +90,7 @@ public class GWikiFileStorage implements GWikiStorage
   /**
    * The standard lock timeout.
    */
-  protected long standardLockTimeout = -1;//TimeInMillis.SECOND * 100;
+  protected long standardLockTimeout = TimeInMillis.SECOND * 100;
 
   /**
    * The storage.


### PR DESCRIPTION
When -1 this will cause a java.lang.IllegalArgumentException: timeout value is negative on linux systems when calling 
 this.wait(timeOut); in
de.micromata.genome.gdbfs.RamFileSystem#runInTransaction(java.lang.String, long, boolean, de.micromata.genome.util.runtime.CallableX<R,java.lang.RuntimeException>)
